### PR TITLE
Updated Inventory with rooted 'with_path' option test.

### DIFF
--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
@@ -82,7 +82,7 @@
       assert:
         that:
           - "'path' in test_host.value"
-          - "'my_center' in test_host.value.group_names"
+          - "'my_center' in test_host.value.path"
 
     - name: Inventory 'with_nested_properties' option
       include_tasks: build_inventory.yml


### PR DESCRIPTION
It makes sense to look for rooted 'path' value in variable instead of group_names